### PR TITLE
Remove subdomain from hostname

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,6 +8,8 @@
 import 'typeface-lato';
 import 'typeface-roboto-mono';
 
+import { getRootDomain } from '@utils';
+
 /**
  * We use an iframe to migrate user storage from landing to app ie. <MigrateLS/>.
  * 1. Since an origin is defined as `<protocol>://<host>:<port>` and the websites have different sub-domains,
@@ -20,4 +22,5 @@ import 'typeface-roboto-mono';
  *     https://developer.mozilla.org/en-US/docs/Web/API/Document/domain)
  * 4. Since we need run 3 environments we dynamically set the domain to the appropriate hostname.
  */
-document.domain = document.location.hostname || 'localhost';
+
+document.domain = getRootDomain(document.location.hostname);

--- a/src/utils/getRootDomain.spec.ts
+++ b/src/utils/getRootDomain.spec.ts
@@ -1,0 +1,25 @@
+import { getRootDomain } from './getRootDomain';
+
+test('it handles undefiend', () => {
+  const hostname = undefined;
+  const res = getRootDomain(hostname);
+  expect(res).toEqual('');
+});
+
+test('it handles localhost', () => {
+  const hostname = 'localhost';
+  const res = getRootDomain(hostname);
+  expect(res).toEqual(hostname);
+});
+
+test('it removes the subdomain from a host name', () => {
+  const hostname = 'sub.root.com';
+  const res = getRootDomain(hostname);
+  expect(res).toEqual('root.com');
+});
+
+test('it handles multiple sub-domains', () => {
+  const hostname = 'sub1.sub2.sub3.root.com';
+  const res = getRootDomain(hostname);
+  expect(res).toEqual('root.com');
+});

--- a/src/utils/getRootDomain.spec.ts
+++ b/src/utils/getRootDomain.spec.ts
@@ -12,6 +12,12 @@ test('it handles localhost', () => {
   expect(res).toEqual(hostname);
 });
 
+test('it handles naked domain', () => {
+  const hostname = 'example.com';
+  const res = getRootDomain(hostname);
+  expect(res).toEqual(hostname);
+});
+
 test('it removes the subdomain from a host name', () => {
   const hostname = 'sub.root.com';
   const res = getRootDomain(hostname);

--- a/src/utils/getRootDomain.ts
+++ b/src/utils/getRootDomain.ts
@@ -1,0 +1,15 @@
+/**
+ * Primitive util to extract root domain from a hostname.
+ * Blindly returns the last 2 dot seperated strings.
+ * Returns empty string if argument is undefined.
+ * @param hostname
+ */
+
+export const getRootDomain = (hostname = '') => {
+  return hostname
+    .split('.')
+    .reverse()
+    .slice(0, 2)
+    .reverse()
+    .join('.');
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { noOp } from './noOp';
 export { getRoute } from './getRoute';
 export { getFeaturedOS } from './getFeaturedOS';
 export { getRelease } from './getRelease';
+export { getRootDomain } from './getRootDomain';


### PR DESCRIPTION
Hostname actually includes the subdomain.
For the cross origin sharing to function we can only use the root domain.
ie. `mycryptobuilds.com` not `landing.mycryptobuilds.com`

Steps to test:
- head to staging url: [https://landing.mycryptobuilds.com/pr/13/](https://landing.mycryptobuilds.com/pr/13/)
- open console
- expect `document.domain` toBe 'mycryptobuilds.com'