### PR TITLE
App csp frame-ancestors

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,5 +69,20 @@ module.exports = {
         siteUrl: 'https://beta.mycrypto.com/',
       },
     },
+    {
+      resolve: `gatsby-plugin-csp`,
+      options: {
+        disableOnDev: true,
+        reportOnly: false, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
+        mergeScriptHashes: true, // you can disable scripts sha256 hashes
+        mergeStyleHashes: true, // you can disable styles sha256 hashes
+        mergeDefaultDirectives: true,
+        directives: {
+          'frame-ancestors':
+            "'self' mycryptobuilds.com app.mycrypto.com mycrypto.com",
+          // you can add your directives or override defaults
+        },
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.14.3",
     "eslint-plugin-testcafe": "^0.2.1",
+    "gatsby-plugin-csp": "^1.1.3",
     "gatsby-plugin-layout": "^1.3.5",
     "gatsby-plugin-react-svg": "3.0.0",
     "husky": "4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,6 +8935,14 @@ gatsby-plugin-alias-imports@1.0.5:
   dependencies:
     "@babel/runtime" "^7.2.0"
 
+gatsby-plugin-csp@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-csp/-/gatsby-plugin-csp-1.1.3.tgz#27258c0f9b94cf17c55b4d42e520de9870031254"
+  integrity sha512-jTAdWpJXCAaqBXAmf07XVnsgHp7tdtC36XrOQUMRMrEOkEIpM+x+4X3Xma4YAmFbuGH+QKRGmbmCCRNhV//EDA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    lodash.flatten "^4.4.0"
+
 gatsby-plugin-layout@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-layout/-/gatsby-plugin-layout-1.3.5.tgz#163682dbdc37408cc9eb4c1ac561bc8924a1b3fa"
@@ -12175,6 +12183,11 @@ lodash.every@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.every/-/lodash.every-4.6.0.tgz#eb89984bebc4364279bb3aefbbd1ca19bfa6c6a7"
   integrity sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
ie. Core Migration from beta to app.
`frame-ancestors` obsoletes the `X-frame-options`
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options