### PR TITLE
Fix SEO title metadata

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -53,7 +53,7 @@ function SEO({
         },
         {
           property: `og:title`,
-          content: title,
+          content: metaTitle,
         },
         {
           property: `og:description`,
@@ -73,7 +73,7 @@ function SEO({
         },
         {
           property: `og:image:alt`,
-          content: title,
+          content: metaTitle,
         },
         {
           property: 'og:image:width',
@@ -93,7 +93,7 @@ function SEO({
         },
         {
           name: `twitter:title`,
-          content: title,
+          content: metaTitle,
         },
         {
           name: `twitter:description`,
@@ -105,7 +105,7 @@ function SEO({
         },
         {
           property: `twitter:image:alt`,
-          content: title,
+          content: metaTitle,
         },
         {
           property: 'twitter:image:width',


### PR DESCRIPTION
## Description
- Replace `title` variable with `metaTitle` to fix SEO meta tags
## Screenshots
### Before
![image](https://user-images.githubusercontent.com/12037024/106190213-9e694b00-61a9-11eb-9816-9f48c445cf92.png)
### After
![image](https://user-images.githubusercontent.com/12037024/106190147-898cb780-61a9-11eb-8c07-ab7170e4c0c1.png)